### PR TITLE
doc: [DA] Remove IMS_TOKEN setup instructions

### DIFF
--- a/support.md
+++ b/support.md
@@ -9,22 +9,6 @@ Access to Experience Catalyst is currently limited to Adobe internal users.
 3. A team member will respond to your Slack message and provision you with a **GitHub code repository** and either a **SharePoint folder** or **DA folder** (depending on your project type). You'll get the link to those in their reply.
 4. You'll also receive a **GitHub invitation email** from the team member doing your provisioning. You'll get that email on the email address associated with the GitHub username you provided, and its subject should be something like "USER invited you to aemysites/YOUR_GIT_REPO".
 5. It's important that in that email, you click the **View invitation** link and then click **Accept invitation** on the page that opens. This step is required to actually activate your access (until you accept, you won't be able to contribute to the GtiHub repository).
-6. For DA project, you'll need an IMS token configured in your GitHub repository secrets for upload and preview functionality to work properly. See [DA Projects: IMS Token Setup](support.md#da-projects-ims-token-setup) on how to generate an IMS token and configure it as a repository secret.
-
-## DA Projects: IMS Token Setup
-
-### Step 1: Generate IMS Token
-- Follow the [IMS API reference](https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/ims#fetching-access-tokens) to generate an Access Token. You may use any IMS org that has permission to preview/publish to Edge Delivery.
-
-### Step 2: Add Token to GitHub Repository
-- Go to your GitHub repository
-- Navigate to `Settings` > `Secrets and variables` > `Actions`
-- Click `New repository secret` with the following:
-    - Name: `IMS_TOKEN`
-    - Value: Your IMS token from Step 1
-
-### Step 3: Verify Setup
-- After setting the token, retry the failed `AEMY Setup Content` issue (the previous run would have failed due to the missing token).
 
 It's time now for you to try out the [Experience Catalyst tutorial](tutorial.md).
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -20,7 +20,6 @@ This guide assumes that the following have been already setup for you as per the
 - A **SharePoint Folder** or **DA Folder** that you have been provisioned with (depending on your project type).
 - A **GitHub Repository** created from [sta-boilerplate](https://github.com/aemdemos/sta-boilerplate), with [AEMY](https://github.com/apps/aem-aemy) and [AEM Code Sync](https://github.com/apps/aem-code-sync) installed, and `fstab.yaml` configured to point to your content source.
 - The **Preview & Live URLs** for viewing your future migrated site.
-- For DA projects, the `IMS_TOKEN` has been added as a repository secret. See [DA Projects: IMS Token Setup](support.md#da-projects-ims-token-setup) if you haven't set it up yet.
 
 Install the [**AEM Sidekick browser extension**](https://www.aem.live/docs/sidekick) for your project as it is helpful for previewing and publishing content updates from your content source (SharePoint or DA) to your Edge Delivery site. Sidekick is not required for using Experience Catalyst itself, which operates independently of the extension.
 
@@ -144,8 +143,6 @@ After this task is finished, you won't get a pull request as in the previous ste
 ### Upload content
 
 In this step, AEMY will upload the generated documents to your content source (SharePoint or DA).
-
-**Note**: For DA projects, you'll need an IMS token for this step. See [DA Projects: IMS Token Setup](support.md#da-projects-ims-token-setup) if you haven't set it up yet.
 
 1. Create a new issue
 2. **Title**: `Upload content`


### PR DESCRIPTION
Our IMSS client will now be used to upload and preview content, till the time DA team exposes a card in Admin Console that allows users to get an IMS token with required scopes for interacting with DA and Helix Admin APIs.